### PR TITLE
fix coffeescript loaded by turbolinks

### DIFF
--- a/app/assets/javascripts/notes.coffee
+++ b/app/assets/javascripts/notes.coffee
@@ -2,7 +2,15 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
-$ ->
-    $('#note_markdown').on 'keyup', =>
-        $('#compiled').html marked $('#note_markdown').val()
-    .trigger 'keyup'
+event = 'keyup'
+body = 'body'
+source = '#note_markdown'
+target = '#compiled'
+
+attachMarkdownChangedHandler = ->
+    $(source).on event, ->
+        $(target).html marked $(source).val()
+    .trigger event
+    
+$(document).on 'page:load', attachMarkdownChangedHandler
+$(document).ready attachMarkdownChangedHandler


### PR DESCRIPTION
turbolinks doesn't run dom events
to get js events bound, you must handle turbolinks home-grown 'page:load' event