### PR TITLE
display timestamp

### DIFF
--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -14,3 +14,8 @@ textarea#note_markdown {
   width: 500px;
   height: 150px;
 }
+
+.field .stamp {
+    color:hsl(0,0%,50%);
+    font-size:12px;
+}

--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -11,6 +11,13 @@
     </div>
   <% end %>
 
+  <% unless @note.created_at.blank? %>
+    <div class="field">
+      <div class="stamp">created: <%= @note.created_at %></div>
+      <div class="stamp">last update: <%= @note.updated_at %></div>
+    </div>
+  <% end %>
+  
   <div class="field">
     <%= f.label :title %><br>
     <%= f.text_field :title, maxLength: 250 %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:default] = ->(date) { date.strftime("%A, %B #{date.day.ordinalize}, %Y at %l:%M%p") }


### PR DESCRIPTION
change default datetime format
show on note's form partial
minimial styling, because 'bored'