### PR TITLE
test note gets set to inactive, and redirects to trashcan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+cache:
+  - bundler
+before_install:
+  - gem install bundler --version 1.10.6
+rvm:
+  - 2.2.3
+script:
+  - bundle exec rake db:migrate
+  - bundle exec rake db:test:prepare
+  - bundle exec rake test
+env:
+  - DB=sqlite

--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,7 @@ group :development, :test do
 
 end
 
+group :test do
+  gem 'rake'
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ DEPENDENCIES
   marked-rails
   rails (= 4.2.1)
   rails4-autocomplete
+  rake
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sqlite3
@@ -162,4 +163,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.3
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+#Markdown's public facing website [![Build Status](https://travis-ci.org/CVTCMarkdown/markdown.svg?branch=master)](https://travis-ci.org/CVTCMarkdown/markdown?branch=master)

--- a/app/controllers/trashed_notes_controller.rb
+++ b/app/controllers/trashed_notes_controller.rb
@@ -14,7 +14,7 @@ class TrashedNotesController < ApplicationController
 
   def destroy
     if @note.destroy
-      redirect_to trashed_notes_url(), notice: "The note is now gone"
+      redirect_to trashed_notes_url(), notice: 'Note was successfully destroyed.'
     end
   end
   

--- a/test/controllers/trashed_notes_controller_test.rb
+++ b/test/controllers/trashed_notes_controller_test.rb
@@ -1,19 +1,40 @@
 require 'test_helper'
 
 class TrashedNotesControllerTest < ActionController::TestCase
+  setup do
+    @note = notes(:deletedNote)
+  end
+
   test "should get index" do
     get :index
     assert_response :success
   end
 
   test "should get update" do
-    get :update
-    assert_response :success
+
+    assert_difference("Note.where('active=?', false).count", -1) do
+      assert_difference("Note.where('active=?',true).count", 1) do
+        patch :update, id: @note
+      end
+    end
+
+    assert_redirected_to trashed_notes_path
+
+    assert_equal 'Note was successfully restored.', flash[:notice]
+
   end
 
   test "should get destroy" do
-    get :destroy
-    assert_response :success
+    assert_difference("Note.where('active=?', false).count", -1) do
+      assert_difference("Note.count", -1) do
+        delete :destroy, id: @note
+      end
+    end
+
+    assert_redirected_to trashed_notes_path
+
+    assert_equal 'Note was successfully destroyed.', flash[:notice]
+
   end
 
 end

--- a/test/fixtures/notes.yml
+++ b/test/fixtures/notes.yml
@@ -13,6 +13,6 @@ two:
   active: true
   
 deletedNote:
-  title: Title 1
-  markdown: #Markdown is awesome
+  title: Old Trashed Note
+  markdown: Markdown is awesome
   active: false

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -15,4 +15,19 @@ class NoteTest < ActiveSupport::TestCase
     @note.unshare
     assert @note.shared_token.blank?
   end
+
+  test "can't save without title" do
+    @note.title = nil
+    assert_not @note.save
+  end
+
+  test "can't save without markdown" do
+    @note.markdown = nil
+    assert_not @note.save
+  end
+
+  test "can't save with title over 250 characters" do
+    @note.title = "title" * 51
+    assert_not @note.save
+  end
 end


### PR DESCRIPTION
test note can be restored and supplies correct flash notice
test note can be permanantly destroyed and supplies correct flash notice
test that note gets set to inactive, and redirects to trashcan
test that note can be restored and supplies correct flash notice
test that note can be permanantly destroyed and supplies correct flash notice
test that note gets set to inactive, and redirects to trashcan
test that note can be restored and supplies correct flash notice
test that note can be permanantly destroyed and supplies correct flash notice
test edit page has title, tag_list, and markdown fields
test validation of note
test validation of title length
test note title field has a client side max length of 250
test that titles are links
add travis configuration
add travis build status to readme